### PR TITLE
Refactor sections, add About Me navigation, and configure GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# neilthomass.github.io
+
+Personal website built with Vite, React, and Tailwind CSS.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Deployment
+
+The site is published to GitHub Pages via the workflow in
+[.github/workflows/deploy.yml](.github/workflows/deploy.yml).

--- a/src/components/AboutMeSection.tsx
+++ b/src/components/AboutMeSection.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
 const AboutMeSection = () => (
-  <section className="w-full flex my-24 px-6 md:px-12 lg:px-24">
-    <div className="w-3/4 max-w-lg ml-auto text-left py-16">
+  <section id="about-me" className="w-full flex my-24 px-6 md:px-12 lg:px-24">
+    <div className="w-3/4 mx-auto text-left py-16">
       <h2 className="text-5xl md:text-6xl font-extrabold uppercase mb-8 tracking-tight text-white">
         ABOUT ME
       </h2>
       <p className="text-xl md:text-2xl text-white/90 leading-relaxed whitespace-pre-line">
         As a Computer Science student at UC Berkeley, I am fascinated by the power of algorithms and the potential of machine learning to transform the world. My academic journey has centered on building robust software, exploring data-driven solutions, and applying modern ML techniques to real-world problems.
-        
+
         I am passionate about leveraging technology to solve complex challenges, from developing intelligent systems to creating impactful user experiences. At Berkeley, I thrive in a community that values innovation, collaboration, and pushing the boundaries of what is possible in computer science and artificial intelligence.
       </p>
     </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -26,6 +26,13 @@ const Navigation = () => {
           </Button>
           <Button
             variant="ghost"
+            onClick={() => scrollToSection("about-me")}
+            className="text-white hover:text-white/80 hover:bg-white/10"
+          >
+            About Me
+          </Button>
+          <Button
+            variant="ghost"
             onClick={() => scrollToSection("skills")}
             className="text-white hover:text-white/80 hover:bg-white/10"
           >

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -1,0 +1,50 @@
+const SkillsSection = () => {
+  const skills = [
+    { name: "Python", icon: "/src/images/python.svg" },
+    { name: "C++", icon: "/src/images/cplusplus.svg" },
+    { name: "Java", icon: "/src/images/java.svg" },
+    { name: "AWS", icon: "/src/images/amazonaws.svg" },
+    { name: "Rust", icon: "/src/images/rust.svg" },
+    { name: "NodeJS", icon: "/src/images/nodedotjs.svg" },
+    { name: "ReactJS", icon: "/src/images/react.svg" },
+    { name: "Next.js", icon: "/src/images/nextdotjs.svg" },
+    { name: "MySQL", icon: "/src/images/mysql.svg" },
+    { name: "Flask", icon: "/src/images/flask.svg" },
+    { name: "PyTorch", icon: "/src/images/pytorch.svg" },
+    { name: "TensorFlow", icon: "/src/images/tensorflow.svg" },
+    { name: "Pandas", icon: "/src/images/pandas.svg" },
+    { name: "NumPy", icon: "/src/images/numpy.svg" },
+    { name: "HTML", icon: "/src/images/html5.svg" },
+    { name: "TailwindCSS", icon: "/src/images/tailwindcss.svg" }
+  ];
+
+  return (
+    <section id="skills" className="py-12 px-6 md:px-12 lg:px-24 pb-40">
+      <div className="w-full">
+        <h2 className="text-4xl md:text-5xl font-bold mb-8 tracking-tight text-center text-white">
+          Skills
+        </h2>
+
+        <div className="grid grid-cols-4 gap-8 w-full">
+          {skills.map((skill, index) => (
+            <div
+              key={index}
+              className="text-center group p-6 bg-transparent border-2 border-white rounded-lg hover:border-white/80 transition-all duration-300 hover:scale-105"
+            >
+              <div className="w-16 h-16 mx-auto mb-4 group-hover:scale-110 transition-transform duration-300">
+                <img
+                  src={skill.icon}
+                  alt={skill.name}
+                  className="w-full h-full object-contain"
+                />
+              </div>
+              <h3 className="text-lg font-semibold text-white">{skill.name}</h3>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default SkillsSection;

--- a/src/components/WorkSection.tsx
+++ b/src/components/WorkSection.tsx
@@ -56,90 +56,40 @@ const WorkSection = () => {
     }
   ];
 
-  const skills = [
-    { name: "Python", icon: "/src/images/python.svg" },
-    { name: "C++", icon: "/src/images/cplusplus.svg" },
-    { name: "Java", icon: "/src/images/java.svg" },
-    { name: "AWS", icon: "/src/images/amazonaws.svg" },
-    { name: "Rust", icon: "/src/images/rust.svg" },
-    { name: "NodeJS", icon: "/src/images/nodedotjs.svg" },
-    { name: "ReactJS", icon: "/src/images/react.svg" },
-    { name: "Next.js", icon: "/src/images/nextdotjs.svg" },
-    { name: "MySQL", icon: "/src/images/mysql.svg" },
-    { name: "Flask", icon: "/src/images/flask.svg" },
-    { name: "PyTorch", icon: "/src/images/pytorch.svg" },
-    { name: "TensorFlow", icon: "/src/images/tensorflow.svg" },
-    { name: "Pandas", icon: "/src/images/pandas.svg" },
-    { name: "NumPy", icon: "/src/images/numpy.svg" },
-    { name: "HTML", icon: "/src/images/html5.svg" },
-    { name: "TailwindCSS", icon: "/src/images/tailwindcss.svg" }
-  ];
-
   return (
-    <>
-      <section id="work" className="section-padding bg-black text-white">
-        <div className="max-w-7xl mx-auto">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-bold mb-6 tracking-tight text-white">
-              Selected Work
-            </h2>
-            <p className="text-xl text-white/80 max-w-2xl mx-auto">
-              A collection of projects that showcase my passion.
-            </p>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
-            {projects.map((project, index) => (
-              <a
-                key={index}
-                href={project.link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group p-10 bg-transparent border-2 border-white rounded-lg hover:border-white/80 transition-all duration-300 hover:scale-105 w-full text-center flex flex-col items-center justify-center cursor-pointer"
-              >
-                <h3 className="text-2xl font-bold mb-4 text-white tracking-tight group-hover:text-white/80 transition-colors">
-                  {project.title}
-                </h3>
-                <ul className="text-white/80 text-lg text-left list-disc pl-6 space-y-3">
-                  {project.bullets.map((bullet, i) => (
-                    <li key={i}>{bullet}</li>
-                  ))}
-                </ul>
-              </a>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="skills" className="py-12 px-6 md:px-12 lg:px-24">
-        <div className="w-full">
-          <h2 className="text-4xl md:text-5xl font-bold mb-8 tracking-tight text-center text-white">
-            Skills
+    <section id="work" className="section-padding bg-black text-white">
+      <div className="max-w-7xl mx-auto">
+        <div className="text-center mb-16">
+          <h2 className="text-4xl md:text-5xl font-bold mb-6 tracking-tight text-white">
+            Selected Work
           </h2>
-          
-          <div className="grid grid-cols-4 gap-8 w-full">
-            {skills.map((skill, index) => (
-              <div key={index} className="text-center group p-6 bg-transparent border-2 border-white rounded-lg hover:border-white/80 transition-all duration-300 hover:scale-105">
-                <div className="w-16 h-16 mx-auto mb-4 group-hover:scale-110 transition-transform duration-300">
-                  <img 
-                    src={skill.icon} 
-                    alt={skill.name}
-                    className="w-full h-full object-contain"
-                  />
-                </div>
-                <h3 className="text-lg font-semibold text-white">
-                  {skill.name}
-                </h3>
-              </div>
-            ))}
-          </div>
+          <p className="text-xl text-white/80 max-w-2xl mx-auto">
+            A collection of projects that showcase my passion.
+          </p>
         </div>
-      </section>
 
-      <section className="py-40 bg-transparent">
-        {/* Blank section before footer */}
-      </section>
-    </>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
+          {projects.map((project, index) => (
+            <a
+              key={index}
+              href={project.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group p-10 bg-transparent border-2 border-white rounded-lg hover:border-white/80 transition-all duration-300 hover:scale-105 w-full text-center flex flex-col items-center justify-center cursor-pointer"
+            >
+              <h3 className="text-2xl font-bold mb-4 text-white tracking-tight group-hover:text-white/80 transition-colors">
+                {project.title}
+              </h3>
+              <ul className="text-white/80 text-lg text-left list-disc pl-6 space-y-3">
+                {project.bullets.map((bullet, i) => (
+                  <li key={i}>{bullet}</li>
+                ))}
+              </ul>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 };
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,9 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import HeroSection from "@/components/HeroSection";
 import AboutSection from "@/components/AboutSection";
 import AboutMeSection from "@/components/AboutMeSection";
 import WorkSection from "@/components/WorkSection";
+import SkillsSection from "@/components/SkillsSection";
 import Footer from "@/components/Footer";
 
 const Index = () => {
@@ -18,6 +19,7 @@ const Index = () => {
         <AboutSection />
         <AboutMeSection />
         <WorkSection />
+        <SkillsSection />
         <Footer />
       </div>
     </div>
@@ -25,3 +27,4 @@ const Index = () => {
 };
 
 export default Index;
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- split skills into standalone component for clearer separation of sections
- center About Me block and expose anchor for navigation
- add About Me link to top navigation menu
- fix lint warnings and remove empty interfaces
- add GitHub Pages deployment workflow and set Vite base path

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx eslint src/components/AboutMeSection.tsx src/components/Navigation.tsx src/components/WorkSection.tsx src/components/SkillsSection.tsx src/pages/Index.tsx src/components/ui/command.tsx src/components/ui/textarea.tsx tailwind.config.ts vite.config.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894887bbc70832da33bb6248acb80e0